### PR TITLE
fix call of std.math.cast

### DIFF
--- a/src/de/deserializer.zig
+++ b/src/de/deserializer.zig
@@ -239,12 +239,12 @@ pub fn Deserializer(comptime user_dbt: anytype) type {
 
                 if (int != 0) {
                     // TODO: Does math.cast not accept comptime_int?
-                    int = try std.math.mul(T, int, try std.math.cast(T, radix));
+                    int = try std.math.mul(T, int, std.math.cast(T, radix) orelse return error.Overflow);
                 }
 
                 int = switch (sign) {
-                    .pos => try std.math.add(T, int, try std.math.cast(T, digit)),
-                    .neg => try std.math.sub(T, int, try std.math.cast(T, digit)),
+                    .pos => try std.math.add(T, int, std.math.cast(T, digit) orelse return error.Overflow),
+                    .neg => try std.math.sub(T, int, std.math.cast(T, digit) orelse return error.Overflow),
                 };
             }
 


### PR DESCRIPTION
Due to std lib changes in [this commit](https://github.com/ziglang/zig/commit/0e6285c8fc31ff866df96847fe34e660da38b4a9), some parts of this lib wouldn't compile anymore. This PR fixes those errors.