### PR TITLE
Pass in lifetimes to visitString

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "0.4.0",
     .dependencies = .{
         .getty = .{
-            .url = "https://github.com/getty-zig/getty/archive/31b6704ca2e36297bbcfc11dc2374b4d061cbdcd.tar.gz",
-            .hash = "12207f458f827b47247060ec97b02aa7cd24c9afe81da452b4e90ba4d10af9905dc0",
+            .url = "https://github.com/getty-zig/getty/archive/767c0cd42db9d1fdd2e0f2ae3df1d7ba7d84ec19.tar.gz",
+            .hash = "12201f1bce6cb52b1d354b83c53340a190d8e0071ac9721a86bba2d4dd173c6d96d7",
         },
     },
 }

--- a/src/de/deserializer.zig
+++ b/src/de/deserializer.zig
@@ -70,13 +70,14 @@ pub fn Deserializer(comptime dbt: anytype, comptime Reader: type) type {
             const visitor_info = @typeInfo(Visitor);
 
             const token = try self.parser.nextAlloc(ally, .alloc_if_needed);
-            defer freeToken(ally, token);
 
             switch (token) {
                 .true, .false => {
                     return try visitor.visitBool(ally, De, token == .true);
                 },
                 inline .number, .allocated_number => |slice| {
+                    defer freeToken(ally, token);
+
                     // Integer (with hint)
                     if (visitor_info == .Int) {
                         const sign = visitor_info.Int.signedness;
@@ -120,7 +121,18 @@ pub fn Deserializer(comptime dbt: anytype, comptime Reader: type) type {
                     }
 
                     // Enum, String
-                    return try visitor.visitString(ally, De, slice);
+                    switch (token) {
+                        .string => {
+                            return try visitor.visitString(ally, De, slice, .stack);
+                        },
+                        .allocated_string => {
+                            return try visitor.visitString(ally, De, slice, .heap);
+                        },
+                        // UNREACHABLE: The outer switch guarantees that only
+                        // .string and .allocated_string tokens will reach this
+                        // inner switch.
+                        else => unreachable,
+                    }
                 },
                 .null => {
                     // Void
@@ -189,20 +201,27 @@ pub fn Deserializer(comptime dbt: anytype, comptime Reader: type) type {
             }
 
             const token = try self.parser.nextAlloc(ally, .alloc_if_needed);
-            defer freeToken(ally, token);
 
-            return try switch (token) {
-                inline .string, .allocated_string => |slice| visitor.visitString(ally, De, slice),
-                inline .number, .allocated_number => |slice| switch (slice[0]) {
-                    '0'...'9' => visitor.visitInt(ally, De, try parseInt(u128, slice)),
-                    else => visitor.visitInt(ally, De, try parseInt(i128, slice)),
+            switch (token) {
+                .string => |slice| {
+                    return try visitor.visitString(ally, De, slice, .stack);
+                },
+                .allocated_string => |slice| {
+                    return try visitor.visitString(ally, De, slice, .heap);
+                },
+                inline .number, .allocated_number => |slice| {
+                    defer freeToken(ally, token);
+
+                    return try switch (slice[0]) {
+                        '0'...'9' => visitor.visitInt(ally, De, try parseInt(u128, slice)),
+                        else => visitor.visitInt(ally, De, try parseInt(i128, slice)),
+                    };
                 },
 
-                // UNREACHABLE: The peek switch guarantees that only .number,
-                // .string, .allocated_number, and .allocated_string tokens
-                // reach here.
+                // UNREACHABLE: The peek guarantees that only .number, .string,
+                // .allocated_number, and .allocated_string tokens reach here.
                 else => unreachable,
-            };
+            }
         }
 
         fn deserializeFloat(self: *Self, ally: std.mem.Allocator, visitor: anytype) Err!@TypeOf(visitor).Value {
@@ -336,9 +355,10 @@ pub fn Deserializer(comptime dbt: anytype, comptime Reader: type) type {
             const token = try self.parser.nextAlloc(ally, .alloc_if_needed);
 
             switch (token) {
-                .string => |s| return try visitor.visitString(ally, De, s, .stack),
+                .string => |s| {
+                    return try visitor.visitString(ally, De, s, .stack);
+                },
                 .allocated_string => |s| {
-                    defer freeToken(ally, token);
                     return try visitor.visitString(ally, De, s, .heap);
                 },
 
@@ -432,6 +452,7 @@ pub fn Deserializer(comptime dbt: anytype, comptime Reader: type) type {
 fn MapKeyDeserializer(comptime De: type) type {
     return struct {
         key: []const u8,
+        allocated: bool,
 
         const Self = @This();
 
@@ -475,7 +496,11 @@ fn MapKeyDeserializer(comptime De: type) type {
         }
 
         fn deserializeString(self: *Self, ally: std.mem.Allocator, visitor: anytype) Err!@TypeOf(visitor).Value {
-            return try visitor.visitString(ally, De, self.key);
+            if (self.allocated) {
+                return try visitor.visitString(ally, De, self.key, .heap);
+            }
+
+            return try visitor.visitString(ally, De, self.key, .stack);
         }
     };
 }
@@ -508,12 +533,16 @@ fn MapAccess(comptime D: type) type {
             const token = try self.d.parser.nextAlloc(ally, .alloc_if_needed);
             defer freeToken(ally, token);
 
+            var allocated: bool = undefined;
             const value = switch (token) {
-                inline .string, .allocated_string => |slice| slice,
+                inline .string, .allocated_string => |slice| value: {
+                    allocated = token == .allocated_string;
+                    break :value slice;
+                },
                 else => return error.InvalidType,
             };
 
-            var mkd = MapKeyDeserializer(De){ .key = value };
+            var mkd = MapKeyDeserializer(De){ .key = value, .allocated = allocated };
             var result = try seed.deserialize(ally, mkd.deserializer());
             return result.value;
         }


### PR DESCRIPTION
This _should_ be faster than what we were doing before, since now we are using heap strings directly instead of always copying them.

Edit: 🎉  For some reason, we're slower than we were before all these changes.
```zig
Benchmark 1: ./getty
  Time (mean ± σ):     709.9 ms ±   1.7 ms    [User: 705.7 ms, System: 3.2 ms]
  Range (min … max):   708.2 ms … 713.0 ms    10 runs

Benchmark 2: ./std
  Time (mean ± σ):     483.1 ms ±   1.6 ms    [User: 480.0 ms, System: 2.2 ms]
  Range (min … max):   481.3 ms … 486.3 ms    10 runs

Summary
  ./std ran
    1.47 ± 0.01 times faster than ./getty
```