### PR TITLE
de: Free input to visitString where possible

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "0.4.0",
     .dependencies = .{
         .getty = .{
-            .url = "https://github.com/getty-zig/getty/archive/767c0cd42db9d1fdd2e0f2ae3df1d7ba7d84ec19.tar.gz",
-            .hash = "12201f1bce6cb52b1d354b83c53340a190d8e0071ac9721a86bba2d4dd173c6d96d7",
+            .url = "https://github.com/getty-zig/getty/archive/659373715023c1b24c5948dc9565a285b57143cd.tar.gz",
+            .hash = "12206508aaa0ac7ddfac7d86c36e167a028499dcd360cece1699f4bbaca2d91bb569",
         },
     },
 }


### PR DESCRIPTION
If a string passed to visitString is Heap and isn't used, then we can free it immediately instead of keeping it around forever.